### PR TITLE
Re-throw interrupts when capturing

### DIFF
--- a/src/cells.jl
+++ b/src/cells.jl
@@ -37,7 +37,7 @@ CommonMark.block_modifier(c::CellRule) = CommonMark.Rule(100) do parser, node
     if isjuliacode(node) && iscell(node.meta)
         # Load the module for the current cell and evaluate the contents.
         sandbox = getmodule!(c, node)
-        captured = IOCapture.iocapture(throwerrors=false) do
+        captured = IOCapture.iocapture(throwerrors = :interrupt) do
             include_string(sandbox, node.literal)
         end
         # When the value is displayable as markdown then we reparse that
@@ -72,7 +72,7 @@ CommonMark.inline_modifier(c::CellRule) = CommonMark.Rule(100) do parser, block
     for (node, ent) in block
         if ent && is_inline_code(node) && iscell(node.meta)
             sandbox = getmodule!(c, node)
-            captured = IOCapture.iocapture(throwerrors=false) do
+            captured = IOCapture.iocapture(throwerrors = :interrupt) do
                 include_string(sandbox, node.literal)
             end
             if showable(MIME("text/markdown"), captured.value)


### PR DESCRIPTION
I realized that in #2 I undid the `rethrow(::InterruptException)` part

https://github.com/MichaelHatherly/Publish.jl/blob/c326d80e3a042aa33ff9fa9a36d0a3a25e1d7fc8/src/cells.jl#L184-L189

because `throwerrors = false` also captures interrupts.