### PR TITLE
Fix `deploy` with unrelated files in root directory

### DIFF
--- a/src/deploy.jl
+++ b/src/deploy.jl
@@ -102,7 +102,7 @@ function deploy(
     if versioned
         ## Find the current versions.
         dir = joinpath(filter(!isempty, [dir, name])...)
-        versions = sort!(filter(s->!startswith(s, '.'), readdir(dir)); rev=true)
+        versions = sort!(filter(s->!startswith(s, '.') && isdir(s), readdir(dir)); rev=true)
         ## Write a version.js file containing the list of all versions.
         io = IOBuffer()
         println(io, "var PUBLISH_VERSIONS = [")

--- a/src/deploy.jl
+++ b/src/deploy.jl
@@ -102,7 +102,7 @@ function deploy(
     if versioned
         ## Find the current versions.
         dir = joinpath(filter(!isempty, [dir, name])...)
-        versions = sort!(filter(s->!startswith(s, '.') && isdir(s), readdir(dir)); rev=true)
+        versions = sort!(filter(s->!startswith(s, '.') && isdir(dir, s), readdir(dir)); rev=true)
         ## Write a version.js file containing the list of all versions.
         io = IOBuffer()
         println(io, "var PUBLISH_VERSIONS = [")


### PR DESCRIPTION
When running `deploy` in a folder that contains unrelated files, I've run into an error where it tries to check `file/versions.js` even though `file` is a file in the root directory and not a directory.

This small change filters out files when checking each `versions.js`. Please let me know if I've missed something.