### PR TITLE
change code css formatting to use JuliaMono font for REPL plots 

### DIFF
--- a/_themes/default/publish.css
+++ b/_themes/default/publish.css
@@ -10,6 +10,8 @@
     font-size: 62.5%;
 }
 
+@import url("https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.044/juliamono.css");
+
 html {
     font-family: "Open Sans", sans-serif;
     text-size-adjust: none;
@@ -26,7 +28,7 @@ body {
 }
 
 code {
-    font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace !important;
+    font-family: JuliaMono, "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace !important;
     font-size: 0.875em;
 }
 


### PR DESCRIPTION
This should improve the quality of REPL plotting because the JuliaMono font has the required glyphs. @MichaelHatherly, I'm not quite sure how to add tests for this since the difference is a purely visual thing. What would you suggest?