### PR TITLE
Add xvfb-run to Publish.yml github action so plots will render

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build and deploy
         run: |
           cd gh-pages
-          julia --color=yes --project=.. -e 'using Publish; deploy(Publish; root="/Publish.jl", label="dev")'
+          xvfb-run julia --color=yes --project=.. -e 'using Publish; deploy(Publish; root="/Publish.jl", label="dev")'
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .

--- a/.github/workflows/PublishStable.yml
+++ b/.github/workflows/PublishStable.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build and deploy
         run: |
           cd gh-pages
-          julia --color=yes --project=.. -e 'using Publish; deploy(Publish; root="/Publish.jl", label="stable")'
+          xvfb-run julia --color=yes --project=.. -e 'using Publish; deploy(Publish; root="/Publish.jl", label="stable")'
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .


### PR DESCRIPTION
github servers are headless so if you have a plot in your documentation you will get a run time error when the Publish.yml action is executed on github. The error message is not particularly informative so it can be hard for less experienced users to figure out what caused the problem.

This PR fixes the errors caused by not having graphical support. However, there are other errors which I am still debugging. So far I have not been able to get Publish.jl to correctly deploy gh-pages documentation. It works on my local machine but not on github.

Not sure how to write tests for this either because it fixes a github action.